### PR TITLE
Add FoundryMacroExample app showcasing @FoundryGenerable usage

### DIFF
--- a/Examples/FoundryMacroExample/FoundryMacroExample.xcodeproj/project.pbxproj
+++ b/Examples/FoundryMacroExample/FoundryMacroExample.xcodeproj/project.pbxproj
@@ -1,0 +1,474 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2341D74337940860F5695C08 /* FoundryMacroExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C719CC205B16D17610EB6355 /* FoundryMacroExampleApp.swift */; };
+		3B4C132B848C6AD0330D818A /* FoundryMacroExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C719CC205B16D17610EB6355 /* FoundryMacroExampleApp.swift */; };
+		4D7DBFC537E1E88B3A5585CC /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADDA27895EB9172513F3362 /* Models.swift */; };
+		69CEB360721073A6223C0243 /* FoundryKit in Frameworks */ = {isa = PBXBuildFile; productRef = BF5158EFD7E1146E04F31194 /* FoundryKit */; };
+		A427179CCF1E1FB6157F3EF4 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADDA27895EB9172513F3362 /* Models.swift */; };
+		C12E8677A6A323877D7C9460 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432FC93A305E71FAD4B1E254 /* ContentView.swift */; };
+		D6233A262AC35E9F10217D20 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432FC93A305E71FAD4B1E254 /* ContentView.swift */; };
+		FBC7FC1B9ABA25449BDB9825 /* FoundryKit in Frameworks */ = {isa = PBXBuildFile; productRef = AC61771EB0BEE03BE247A1A7 /* FoundryKit */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		3ADDA27895EB9172513F3362 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		432FC93A305E71FAD4B1E254 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		68A3A1EDCFEA0ED1A1CC3D39 /* FoundryMacroExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FoundryMacroExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		99E8F97523597BC1EB122B7D /* FoundryMacroExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FoundryMacroExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCC8DD3C7968D33F2E3D90D1 /* FoundryKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FoundryKit; path = ../..; sourceTree = SOURCE_ROOT; };
+		C719CC205B16D17610EB6355 /* FoundryMacroExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundryMacroExampleApp.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		116ECAB1740C22A8CD924408 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				69CEB360721073A6223C0243 /* FoundryKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A29E71B6BF5B00AE1E52E69C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FBC7FC1B9ABA25449BDB9825 /* FoundryKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6DB4E71E926750B582F9197C = {
+			isa = PBXGroup;
+			children = (
+				B8DB43D9ACBCC82E36F25990 /* FoundryMacroExample */,
+				99E751344445A8C56D4845F6 /* Packages */,
+				9E99E57E3291C0DDD1F197FC /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		99E751344445A8C56D4845F6 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				BCC8DD3C7968D33F2E3D90D1 /* FoundryKit */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		9E99E57E3291C0DDD1F197FC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				99E8F97523597BC1EB122B7D /* FoundryMacroExample.app */,
+				68A3A1EDCFEA0ED1A1CC3D39 /* FoundryMacroExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B8DB43D9ACBCC82E36F25990 /* FoundryMacroExample */ = {
+			isa = PBXGroup;
+			children = (
+				432FC93A305E71FAD4B1E254 /* ContentView.swift */,
+				C719CC205B16D17610EB6355 /* FoundryMacroExampleApp.swift */,
+				3ADDA27895EB9172513F3362 /* Models.swift */,
+			);
+			path = FoundryMacroExample;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		56A5DEC0895EE3C7629A782F /* FoundryMacroExample_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 42D9E1C5566D9F95B6442D20 /* Build configuration list for PBXNativeTarget "FoundryMacroExample_iOS" */;
+			buildPhases = (
+				4E1401D6ED63054ECA73229C /* Sources */,
+				A29E71B6BF5B00AE1E52E69C /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FoundryMacroExample_iOS;
+			packageProductDependencies = (
+				AC61771EB0BEE03BE247A1A7 /* FoundryKit */,
+			);
+			productName = FoundryMacroExample_iOS;
+			productReference = 99E8F97523597BC1EB122B7D /* FoundryMacroExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		8FED014A5BF9B52725EF809D /* FoundryMacroExample_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 764BF02B5A8AB7729EE24C82 /* Build configuration list for PBXNativeTarget "FoundryMacroExample_macOS" */;
+			buildPhases = (
+				33305DD9C1954054B5CD164F /* Sources */,
+				116ECAB1740C22A8CD924408 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FoundryMacroExample_macOS;
+			packageProductDependencies = (
+				BF5158EFD7E1146E04F31194 /* FoundryKit */,
+			);
+			productName = FoundryMacroExample_macOS;
+			productReference = 68A3A1EDCFEA0ED1A1CC3D39 /* FoundryMacroExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		EB31722FE185967C76782A75 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = FE3F7097371A970CC4B4A6E2 /* Build configuration list for PBXProject "FoundryMacroExample" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 6DB4E71E926750B582F9197C;
+			packageReferences = (
+				09680CA3CC39C5D80B9553FB /* XCLocalSwiftPackageReference "../.." */,
+			);
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				56A5DEC0895EE3C7629A782F /* FoundryMacroExample_iOS */,
+				8FED014A5BF9B52725EF809D /* FoundryMacroExample_macOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		33305DD9C1954054B5CD164F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C12E8677A6A323877D7C9460 /* ContentView.swift in Sources */,
+				2341D74337940860F5695C08 /* FoundryMacroExampleApp.swift in Sources */,
+				A427179CCF1E1FB6157F3EF4 /* Models.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4E1401D6ED63054ECA73229C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6233A262AC35E9F10217D20 /* ContentView.swift in Sources */,
+				3B4C132B848C6AD0330D818A /* FoundryMacroExampleApp.swift in Sources */,
+				4D7DBFC537E1E88B3A5585CC /* Models.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		3F352C188DE88DBA28FEF378 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Foundry Macro Example";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.foundrykit.macroexample;
+				PRODUCT_NAME = FoundryMacroExample;
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		A4D291D6DC9E71159459CBE3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Foundry Macro Example";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.foundrykit.macroexample;
+				PRODUCT_NAME = FoundryMacroExample;
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		B393D1BF3446E9D6E523557A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Foundry Macro Example";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.foundrykit.macroexample;
+				PRODUCT_NAME = FoundryMacroExample;
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		E2D1227A5BEB9028137F512F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		F403F68B4F59267F24D5C123 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F7469A7FAFEBAB39DB87A3D2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Foundry Macro Example";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.foundrykit.macroexample;
+				PRODUCT_NAME = FoundryMacroExample;
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		42D9E1C5566D9F95B6442D20 /* Build configuration list for PBXNativeTarget "FoundryMacroExample_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F7469A7FAFEBAB39DB87A3D2 /* Debug */,
+				A4D291D6DC9E71159459CBE3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		764BF02B5A8AB7729EE24C82 /* Build configuration list for PBXNativeTarget "FoundryMacroExample_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B393D1BF3446E9D6E523557A /* Debug */,
+				3F352C188DE88DBA28FEF378 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		FE3F7097371A970CC4B4A6E2 /* Build configuration list for PBXProject "FoundryMacroExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F403F68B4F59267F24D5C123 /* Debug */,
+				E2D1227A5BEB9028137F512F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		09680CA3CC39C5D80B9553FB /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AC61771EB0BEE03BE247A1A7 /* FoundryKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FoundryKit;
+		};
+		BF5158EFD7E1146E04F31194 /* FoundryKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FoundryKit;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = EB31722FE185967C76782A75 /* Project object */;
+}

--- a/Examples/FoundryMacroExample/FoundryMacroExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/FoundryMacroExample/FoundryMacroExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/FoundryMacroExample/FoundryMacroExample/ContentView.swift
+++ b/Examples/FoundryMacroExample/FoundryMacroExample/ContentView.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+import FoundryKit
+
+struct ContentView: View {
+    @State private var selectedModel = ModelType.product
+    @State private var showingMLXSchema = false
+    
+    enum ModelType: String, CaseIterable {
+        case product = "Product"
+        case userProfile = "User Profile"
+        
+        var systemImage: String {
+            switch self {
+            case .product: return "shippingbox"
+            case .userProfile: return "person.circle"
+            }
+        }
+    }
+    
+    var body: some View {
+        NavigationSplitView {
+            List(ModelType.allCases, id: \.self, selection: $selectedModel) { model in
+                Label(model.rawValue, systemImage: model.systemImage)
+            }
+            .navigationTitle("FoundryKit Models")
+            #if os(macOS)
+            .navigationSplitViewColumnWidth(min: 200, ideal: 250)
+            #endif
+        } detail: {
+            ModelDetailView(modelType: selectedModel, showingMLXSchema: $showingMLXSchema)
+                .navigationTitle(selectedModel.rawValue)
+                #if os(iOS)
+                .navigationBarTitleDisplayMode(.large)
+                #endif
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        Toggle(isOn: $showingMLXSchema) {
+                            Label("MLX Format", systemImage: showingMLXSchema ? "function" : "curlybraces")
+                        }
+                        .toggleStyle(.button)
+                    }
+                }
+        }
+    }
+}
+
+struct ModelDetailView: View {
+    let modelType: ContentView.ModelType
+    @Binding var showingMLXSchema: Bool
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                switch modelType {
+                case .product:
+                    ModelSchemaView(
+                        title: "Product Model",
+                        description: "E-commerce product with comprehensive validation",
+                        jsonSchema: Product.jsonSchema,
+                        toolCallSchema: Product.toolCallSchema,
+                        exampleJSON: Product.exampleJSON,
+                        showingMLXSchema: showingMLXSchema
+                    )
+                case .userProfile:
+                    ModelSchemaView(
+                        title: "User Profile Model",
+                        description: "User account with validation patterns",
+                        jsonSchema: UserProfile.jsonSchema,
+                        toolCallSchema: UserProfile.toolCallSchema,
+                        exampleJSON: UserProfile.exampleJSON,
+                        showingMLXSchema: showingMLXSchema
+                    )
+                }
+            }
+            .padding()
+        }
+        .background(Color(white: 0.98))
+    }
+}
+
+struct ModelSchemaView: View {
+    let title: String
+    let description: String
+    let jsonSchema: [String: Any]
+    let toolCallSchema: [String: Any]
+    let exampleJSON: String?
+    let showingMLXSchema: Bool
+    
+    @State private var copiedSection: String? = nil
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // Header
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                Text(description)
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.bottom)
+            
+            // Schema Display
+            SchemaSection(
+                title: showingMLXSchema ? "MLX Tool Call Schema" : "JSON Schema",
+                icon: showingMLXSchema ? "function" : "curlybraces",
+                schema: showingMLXSchema ? toolCallSchema : jsonSchema,
+                copiedSection: $copiedSection,
+                sectionId: "schema"
+            )
+            
+            // Example JSON
+            if let exampleJSON = exampleJSON {
+                ExampleSection(
+                    exampleJSON: exampleJSON,
+                    copiedSection: $copiedSection
+                )
+            }
+            
+            // Properties Summary
+            PropertiesSummary(schema: jsonSchema)
+        }
+    }
+}
+
+struct SchemaSection: View {
+    let title: String
+    let icon: String
+    let schema: [String: Any]
+    @Binding var copiedSection: String?
+    let sectionId: String
+    
+    var formattedJSON: String {
+        guard let data = try? JSONSerialization.data(withJSONObject: schema, options: [.prettyPrinted, .sortedKeys]),
+              let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label(title, systemImage: icon)
+                    .font(.headline)
+                Spacer()
+                CopyButton(
+                    text: formattedJSON,
+                    copiedSection: $copiedSection,
+                    sectionId: sectionId
+                )
+            }
+            
+            CodeView(content: formattedJSON)
+        }
+    }
+}
+
+struct ExampleSection: View {
+    let exampleJSON: String
+    @Binding var copiedSection: String?
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Example JSON", systemImage: "doc.text")
+                    .font(.headline)
+                Spacer()
+                CopyButton(
+                    text: exampleJSON,
+                    copiedSection: $copiedSection,
+                    sectionId: "example"
+                )
+            }
+            
+            CodeView(content: exampleJSON)
+        }
+    }
+}
+
+struct PropertiesSummary: View {
+    let schema: [String: Any]
+    
+    struct PropertyInfo: Identifiable {
+        let id = UUID()
+        let name: String
+        let type: String
+        let isRequired: Bool
+        let constraints: [String]
+    }
+    
+    var properties: [PropertyInfo] {
+        guard let schemaProps = schema["properties"] as? [String: Any],
+              let required = schema["required"] as? [String] else { return [] }
+        
+        return schemaProps.compactMap { key, value in
+            guard let propSchema = value as? [String: Any],
+                  let type = propSchema["type"] as? String else { return nil }
+            
+            var constraints: [String] = []
+            
+            // Collect constraints
+            if let min = propSchema["minimum"] as? Int { constraints.append("min: \(min)") }
+            if let max = propSchema["maximum"] as? Int { constraints.append("max: \(max)") }
+            if let minLength = propSchema["minLength"] as? Int { constraints.append("minLength: \(minLength)") }
+            if let maxLength = propSchema["maxLength"] as? Int { constraints.append("maxLength: \(maxLength)") }
+            if let minItems = propSchema["minItems"] as? Int { constraints.append("minItems: \(minItems)") }
+            if let maxItems = propSchema["maxItems"] as? Int { constraints.append("maxItems: \(maxItems)") }
+            if let pattern = propSchema["pattern"] as? String { constraints.append("pattern") }
+            if let enumValues = propSchema["enum"] as? [String] { 
+                constraints.append("enum: [\(enumValues.joined(separator: ", "))]") 
+            }
+            
+            return PropertyInfo(
+                name: key,
+                type: type,
+                isRequired: required.contains(key),
+                constraints: constraints
+            )
+        }.sorted { $0.name < $1.name }
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Properties Summary", systemImage: "list.bullet")
+                .font(.headline)
+            
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(properties) { property in
+                    HStack(alignment: .top) {
+                        Text(property.name)
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundColor(.primary)
+                        
+                        Text("(\(property.type))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        
+                        if property.isRequired {
+                            Text("Required")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.red.opacity(0.1))
+                                .cornerRadius(4)
+                        }
+                        
+                        Spacer()
+                        
+                        if !property.constraints.isEmpty {
+                            Text(property.constraints.joined(separator: ", "))
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .padding()
+            .background(Color.white)
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+            )
+        }
+    }
+}
+
+struct CodeView: View {
+    let content: String
+    
+    var body: some View {
+        ScrollView(.horizontal) {
+            Text(content)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color.white)
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+        )
+    }
+}
+
+struct CopyButton: View {
+    let text: String
+    @Binding var copiedSection: String?
+    let sectionId: String
+    
+    var body: some View {
+        Button(action: {
+            copyToClipboard(text)
+            withAnimation {
+                copiedSection = sectionId
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                copiedSection = nil
+            }
+        }) {
+            Label(
+                copiedSection == sectionId ? "Copied!" : "Copy",
+                systemImage: copiedSection == sectionId ? "checkmark.circle.fill" : "doc.on.doc"
+            )
+            .foregroundColor(copiedSection == sectionId ? .green : .accentColor)
+        }
+        .buttonStyle(.bordered)
+    }
+    
+    func copyToClipboard(_ text: String) {
+        #if os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #else
+        UIPasteboard.general.string = text
+        #endif
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Examples/FoundryMacroExample/FoundryMacroExample/FoundryMacroExampleApp.swift
+++ b/Examples/FoundryMacroExample/FoundryMacroExample/FoundryMacroExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+@main
+struct FoundryMacroExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                #if os(macOS)
+                .frame(minWidth: 900, minHeight: 700)
+                #endif
+        }
+        #if os(macOS)
+        .windowStyle(.titleBar)
+        .windowToolbarStyle(.unified(showsTitle: true))
+        #endif
+    }
+}

--- a/Examples/FoundryMacroExample/FoundryMacroExample/Models.swift
+++ b/Examples/FoundryMacroExample/FoundryMacroExample/Models.swift
@@ -1,0 +1,86 @@
+import Foundation
+import FoundryKit
+import FoundationModels
+
+@FoundryGenerable
+struct Product {
+    @FoundryGuide("Product name")
+    @FoundryValidation(minLength: 3, maxLength: 200)
+    let name: String
+    
+    @FoundryGuide("Product description")
+    @FoundryValidation(maxLength: 1000)
+    let description: String
+    
+    @FoundryGuide("Price in USD")
+    @FoundryValidation(min: 0, max: 999999)
+    let price: Double
+    
+    @FoundryGuide("Product category")
+    @FoundryValidation(enumValues: ["electronics", "clothing", "food", "books", "home", "sports"])
+    let category: String
+    
+    @FoundryGuide("Available stock quantity")
+    @FoundryValidation(min: 0, max: 10000)
+    let stock: Int
+    
+    @FoundryGuide("Product tags for search")
+    @FoundryValidation(minItems: 1, maxItems: 10)
+    let tags: [String]
+    
+    @FoundryGuide("Product SKU code")
+    @FoundryValidation(pattern: "^[A-Z]{3}-\\d{4}-[A-Z]{2}$")
+    let sku: String
+    
+    @FoundryGuide("Is the product currently available")
+    let isAvailable: Bool
+    
+    @FoundryGuide("Optional discount percentage")
+    @FoundryValidation(min: 0, max: 100)
+    let discountPercentage: Int?
+    
+    @FoundryGuide("Product images URLs")
+    @FoundryValidation(minItems: 1, maxItems: 5)
+    let imageUrls: [String]?
+}
+
+// MARK: - User Profile Model
+@FoundryGenerable
+struct UserProfile {
+    @FoundryGuide("User's unique identifier")
+    let userId: String
+    
+    @FoundryGuide("Username for login")
+    @FoundryValidation(minLength: 3, maxLength: 30, pattern: "^[a-zA-Z0-9_]+$")
+    let username: String
+    
+    @FoundryGuide("User's email address")
+    @FoundryValidation(pattern: "^[\\w\\.-]+@[\\w\\.-]+\\.\\w+$")
+    let email: String
+    
+    @FoundryGuide("User's full name")
+    @FoundryValidation(minLength: 2, maxLength: 100)
+    let fullName: String
+    
+    @FoundryGuide("User's age")
+    @FoundryValidation(min: 13, max: 120)
+    let age: Int
+    
+    @FoundryGuide("Account type")
+    @FoundryValidation(enumValues: ["free", "premium", "enterprise"])
+    let accountType: String
+    
+    @FoundryGuide("Account creation date")
+    @FoundryValidation(pattern: "^\\d{4}-\\d{2}-\\d{2}$")
+    let createdDate: String
+    
+    @FoundryGuide("Is email verified")
+    let isEmailVerified: Bool
+    
+    @FoundryGuide("User's bio")
+    @FoundryValidation(maxLength: 500)
+    let bio: String?
+    
+    @FoundryGuide("Social media handles")
+    let socialHandles: [String]?
+}

--- a/Examples/FoundryMacroExample/README.md
+++ b/Examples/FoundryMacroExample/README.md
@@ -1,0 +1,105 @@
+# FoundryKit Macro Example
+
+This example demonstrates the `@FoundryGenerable` macro from FoundryKit, which automatically generates JSON schemas and MLX tool call schemas for Swift structs.
+
+## Features Demonstrated
+
+### 1. Automatic Schema Generation
+The example shows two models with the `@FoundryGenerable` macro:
+- **Product Model**: E-commerce product with various validation constraints
+- **User Profile Model**: User account with pattern validation and optional fields
+
+### 2. Validation Attributes
+- `@FoundryGuide`: Adds descriptions to properties
+- `@FoundryValidation`: Adds constraints like min/max values, string lengths, patterns, and enums
+
+### 3. Generated Outputs
+Each model automatically generates:
+- **JSON Schema**: Standard JSON Schema format for validation
+- **MLX Tool Call Schema**: Function calling format for MLX Swift
+- **Example JSON**: Realistic example data respecting validation rules
+
+## Running the Example
+
+1. Generate the Xcode project:
+   ```bash
+   cd Examples/FoundryMacroExample
+   xcodegen generate
+   ```
+
+2. Open the generated project:
+   ```bash
+   open FoundryMacroExample.xcodeproj
+   ```
+
+3. Build and run for either iOS or macOS
+
+## Key Features
+
+### JSON Schema Generation
+```swift
+@FoundryGenerable
+struct Product {
+    @FoundryGuide("Product name")
+    @FoundryValidation(minLength: 3, maxLength: 200)
+    let name: String
+    
+    @FoundryGuide("Price in USD")
+    @FoundryValidation(min: 0, max: 999999)
+    let price: Double
+}
+```
+
+Generates:
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Product name",
+      "minLength": 3,
+      "maxLength": 200
+    },
+    "price": {
+      "type": "number",
+      "description": "Price in USD",
+      "minimum": 0,
+      "maximum": 999999
+    }
+  },
+  "required": ["name", "price"]
+}
+```
+
+### MLX Tool Call Schema
+The same model also generates an MLX-compatible schema:
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "generate_product",
+    "description": "Generate a structured Product object",
+    "parameters": {
+      "type": "object",
+      "properties": { ... },
+      "required": [ ... ]
+    }
+  }
+}
+```
+
+## Supported Validations
+
+- **Numeric**: `min`, `max`
+- **String**: `minLength`, `maxLength`, `pattern`
+- **Array**: `minItems`, `maxItems`
+- **Enum**: `enumValues`
+
+## UI Features
+
+- Toggle between JSON Schema and MLX Tool Call Schema views
+- Copy schemas to clipboard
+- Properties summary with constraints
+- Example JSON generation
+- Cross-platform support (iOS and macOS)

--- a/Examples/FoundryMacroExample/project.yml
+++ b/Examples/FoundryMacroExample/project.yml
@@ -1,0 +1,43 @@
+name: FoundryMacroExample
+options:
+  bundleIdPrefix: com.foundrykit
+  deploymentTarget:
+    iOS: "18.0"
+    macOS: "15.0"
+  
+targets:
+  FoundryMacroExample:
+    type: application
+    platform: [iOS, macOS]
+    sources: 
+      - FoundryMacroExample
+    dependencies:
+      - package: FoundryKit
+        product: FoundryKit
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.foundrykit.macroexample
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        SWIFT_VERSION: 6.0
+        SWIFT_STRICT_CONCURRENCY: complete
+        SWIFT_EMIT_LOC_STRINGS: YES
+        INFOPLIST_KEY_CFBundleDisplayName: "Foundry Macro Example"
+        INFOPLIST_KEY_LSApplicationCategoryType: "public.app-category.developer-tools"
+        MARKETING_VERSION: "1.0"
+        CURRENT_PROJECT_VERSION: "1"
+      configs:
+        Debug:
+          SWIFT_OPTIMIZATION_LEVEL: "-Onone"
+          ENABLE_PREVIEWS: YES
+        Release:
+          SWIFT_OPTIMIZATION_LEVEL: "-O"
+          ENABLE_PREVIEWS: NO
+
+packages:
+  FoundryKit:
+    path: ../..


### PR DESCRIPTION
## Summary
- Created a SwiftUI example app that demonstrates the @FoundryGenerable macro functionality
- Added interactive views to display both JSON schemas and MLX tool call schemas
- Supports iOS 26.0+ and macOS 26.0+ with Swift 6.2

## Test plan
- [ ] Build and run the example app on iOS simulator
- [ ] Build and run the example app on macOS
- [ ] Verify schema generation displays correctly
- [ ] Test copy functionality for schemas
- [ ] Ensure toggle between JSON and MLX schemas works